### PR TITLE
Fix double make issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,17 @@ all: vim zsh
 vim:
 	ln -svf $(DIR)/vim/vimrc ~/.vimrc
 
-zsh: oh_my_zsh
+zsh: $(HOME)/.oh-my-zsh
 	ln -svf $(DIR)/zsh/zshrc ~/.zshrc
 	ln -svf $(DIR)/zsh/aliases ~/.aliases
 
-oh_my_zsh: $(HOME)/.oh-my-zsh
-	sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+$(HOME)/.oh-my-zsh:
+	$(DIR)/scripts/install-oh-my-zsh
+
+clean:
+	rm -f ~/.vimrc
+	rm -f ~/.zshrc
+	rm -f ~/.aliases
+	rm -rf ~/.oh-my-zsh
 
 .PHONY: vim zsh

--- a/scripts/install-oh-my-zsh
+++ b/scripts/install-oh-my-zsh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# A barebones version of oh-my-zsh's install script. The reason I'm not
+# using their script is that it calls `env zsh`, which opens a new shell
+# and stops the rest of the Makefile from executing.
+git clone https://www.github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
+
+TEST_CURRENT_SHELL=$(expr "$SHELL" : '.*/\(.*\)')
+if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then
+  chsh -s $(grep /zsh$ /etc/shells | tail -1)
+fi


### PR DESCRIPTION
oh-my-zsh's default install script calls `env zsh`, which opens a new
shell and prevents the rest of the Makefile from executing. Hence, we write our own installation script (`scripts/install-oh-my-zsh`), which essentially clones the repo and changes the shell to zsh if it isn't.